### PR TITLE
victara: Fix haptic feedback on softkeys

### DIFF
--- a/overlay/frameworks/base/core/res/res/values/config.xml
+++ b/overlay/frameworks/base/core/res/res/values/config.xml
@@ -106,13 +106,11 @@
     <!-- Vibrator pattern for feedback about a long screen/key press -->
     <integer-array name="config_longPressVibePattern">
         <item>0</item>
-        <item>0</item>
         <item>105</item>
     </integer-array>
 
     <!-- Vibrator pattern for feedback about touching a virtual key -->
     <integer-array name="config_virtualKeyVibePattern">
-        <item>0</item>
         <item>0</item>
         <item>24</item>
     </integer-array>


### PR DESCRIPTION
If the 2nd value is 0, then there is no feedback on the softkeys.

Im not sure why, as 0,0,24 is what stock uses
